### PR TITLE
Fix copying sequence hints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :test, :development do
   gem 'rb-fsevent', '~> 0.9.2'
   gem 'sqlite3', '~> 1.3.4'
   gem 'rubygems-bundler', '~> 1.1.1'
+  gem 'pry-rails', '~> 0.3.4'
   gem 'pry', '~> 0.9.10'
   gem 'pry-doc', '~> 0.4.4'
   gem 'pry-stack_explorer', '~> 0.4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       yard (~> 0.8.1)
     pry-nav (0.2.3)
       pry (~> 0.9.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     pry-stack_explorer (0.4.7)
       binding_of_caller (~> 0.6.8)
     rack (1.2.8)
@@ -246,6 +248,7 @@ DEPENDENCIES
   pry (~> 0.9.10)
   pry-doc (~> 0.4.4)
   pry-nav (~> 0.2.2)
+  pry-rails (~> 0.3.4)
   pry-stack_explorer (~> 0.4.7)
   rack-environmental
   railroady (~> 1.0.7)

--- a/app/models/constructed_response_sequence.rb
+++ b/app/models/constructed_response_sequence.rb
@@ -24,7 +24,8 @@ class ConstructedResponseSequence < ActiveRecord::Base
 
   def to_hash
     hash = {
-      'type' => 'ConstructedResponseSequence',
+      "title" => title,
+      'type'  => 'ConstructedResponseSequence',
       'initialPrompt' => initial_prompt,
     }
     hash['initialContent'] = initial_content if initial_content

--- a/app/models/constructed_response_sequence.rb
+++ b/app/models/constructed_response_sequence.rb
@@ -1,20 +1,20 @@
 class ConstructedResponseSequence < ActiveRecord::Base
 
   hobo_model # Don't put anything above this
-  
+
   # standard owner and admin permissions
   # defined in models/standard_permissions.rb
   include SgPermissions
   include SgMarshal
   sg_parent :page
-  
+
   fields do
     title         :string
     initial_prompt :raw_html
     initial_content :raw_html
     timestamps
   end
-  
+
   validates :title, :presence => true
 
   has_one :page_sequence, :as => :sequence, :dependent => :destroy

--- a/app/models/line_construction_sequence.rb
+++ b/app/models/line_construction_sequence.rb
@@ -27,9 +27,9 @@ class LineConstructionSequence < ActiveRecord::Base
     y_intercept_tolerance :float,  :default => 0.1
     max_attempts          :integer, :default => 3
     initial_prompt        :raw_html
-    confirm_correct       :raw_html  
-    slope_incorrect       :raw_html  
-    y_intercept_incorrect :raw_html  
+    confirm_correct       :raw_html
+    slope_incorrect       :raw_html
+    y_intercept_incorrect :raw_html
     all_incorrect         :raw_html
     give_up               :raw_html
     timestamps
@@ -42,11 +42,11 @@ class LineConstructionSequence < ActiveRecord::Base
   has_one :page_sequence, :as => :sequence, :dependent => :destroy
   has_one :page, :through => :page_sequence
   reverse_association_of :page, 'Page#line_construction_sequences'
-  
+
   before_validation :default_text_values
 
   belongs_to :data_set
-  
+
   validates :title,                 :presence => true
   validates :initial_prompt,        :presence => true
   validates :confirm_correct,       :presence => true
@@ -98,6 +98,6 @@ class LineConstructionSequence < ActiveRecord::Base
       # self.attributes[key] ||= value
       self.send("#{key}=", value) if self.send(key).nil? || self.send(key).empty?
     end
-  end  
+  end
 
 end

--- a/app/models/line_construction_sequence.rb
+++ b/app/models/line_construction_sequence.rb
@@ -62,6 +62,7 @@ class LineConstructionSequence < ActiveRecord::Base
 
   def to_hash
     {
+        "title"               => title,
         "type"                => type,
         "slope"               => slope,
         "slopeTolerance"      => slope_tolerance,

--- a/app/models/numeric_sequence.rb
+++ b/app/models/numeric_sequence.rb
@@ -1,14 +1,14 @@
 class NumericSequence < ActiveRecord::Base
 
   hobo_model # Don't put anything above this
-  
+
   # standard owner and admin permissions
   # defined in models/standard_permissions.rb
   include SgPermissions
   include SgMarshal
   include SgSequencePrompts
   sg_parent :page
-  
+
   fields do
     title           :string
     initial_prompt  :raw_html
@@ -28,7 +28,7 @@ class NumericSequence < ActiveRecord::Base
   validates :give_up, :presence => true
   validates :confirm_correct, :presence => true
   validates :correct_answer, :presence => true
-  
+
   has_one :page_sequence, :as => :sequence, :dependent => :destroy
 
   has_one :page, :through => :page_sequence

--- a/app/models/numeric_sequence.rb
+++ b/app/models/numeric_sequence.rb
@@ -74,6 +74,7 @@ class NumericSequence < ActiveRecord::Base
 
   def to_hash
     hash = {
+      'title' => title,
       'type' => 'NumericSequence',
       'initialPrompt' => {'text' => initial_prompt.to_s },
       'correctAnswer' => correct_answer,
@@ -89,9 +90,11 @@ class NumericSequence < ActiveRecord::Base
   def data_set_name_from_hash(definition)
     callback = Proc.new do
       self.reload
-      found_data_set = self.page.activity.data_sets.find_by_name(definition)
-      self.data_set = found_data_set
-      self.save!
+      if self.page
+        found_data_set = self.page.activity.data_sets.find_by_name(definition)
+        self.data_set = found_data_set
+        self.save!
+      end
     end
     self.add_marshal_callback(callback)
   end

--- a/app/models/point_axis_line_visual_prompt.rb
+++ b/app/models/point_axis_line_visual_prompt.rb
@@ -1,14 +1,13 @@
 class PointAxisLineVisualPrompt < ActiveRecord::Base
 
   hobo_model # Don't put anything above this
-  
+
   # standard owner and admin permissions
   # defined in models/standard_permissions.rb
   include SgPermissions
   include SgMarshal
   include SgVisualPrompt
 
-  # sg_parent :any_prompt
   sg_parent :any_sequence
 
   fields do

--- a/app/models/point_circle_visual_prompt.rb
+++ b/app/models/point_circle_visual_prompt.rb
@@ -1,14 +1,13 @@
 class PointCircleVisualPrompt < ActiveRecord::Base
 
   hobo_model # Don't put anything above this
-  
+
   # standard owner and admin permissions
   # defined in models/standard_permissions.rb
   include SgPermissions
   include SgMarshal
   include SgVisualPrompt
   
-  # sg_parent :any_prompt
   sg_parent :any_sequence
 
   fields do

--- a/app/models/range_visual_prompt.rb
+++ b/app/models/range_visual_prompt.rb
@@ -1,14 +1,14 @@
 class RangeVisualPrompt < ActiveRecord::Base
 
   hobo_model # Don't put anything above this
-  
+
   # standard owner and admin permissions
   # defined in models/standard_permissions.rb
   include SgPermissions
   include SgMarshal
-  # sg_parent :any_prompt
-  sg_parent :any_sequence
   
+  sg_parent :any_sequence
+
   fields do
     name  :string
     x_min :float

--- a/app/models/sg_sequence_prompts.rb
+++ b/app/models/sg_sequence_prompts.rb
@@ -22,12 +22,18 @@ module SgSequencePrompts
   end
 
   def initial_prompt_from_hash(defs)
-    self.initial_prompt = defs['text']
     if self.respond_to?(:answer_with_label) && defs['label']
       self.answer_with_label = true
     end
-    if self.respond_to?(:title)
-      self.title          = defs['text'] # sequences with titles don't include them in their hash, so we use the initial_prompt
+    prompt = defs['text']
+    unless prompt.blank?
+      self.initial_prompt = prompt
+      if self.respond_to?(:title)
+        if self.title.blank?
+          # title is DB constrainted to 255 chars.
+          self.title = prompt.runcate(255)
+        end
+      end
     end
     add_visual_prompts(defs,'initial')
   end

--- a/app/models/sg_sequence_prompts.rb
+++ b/app/models/sg_sequence_prompts.rb
@@ -70,5 +70,5 @@ module SgSequencePrompts
       hash['confirmCorrect']['visualPrompts'] = confirm_correct_prompts.map {|p| p.prompt.to_hash }
     end
   end
-  
+
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -142,6 +142,7 @@ describe Activity do
       })
       @original.copy_activity
     end
+
     let(:derivative) { FactoryGirl.create(:data_set, :name => 'Derivative', :derivative_of_id => @data_set.id) }
 
     it "should match original" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -140,6 +140,32 @@ describe Activity do
         :label_sets => [@label_set],
         :pages      => [@page]
       })
+      @page2 = Page.new(:name => "test-2")
+      @numeric_sequence = NumericSequence.create({
+        :title  => "pick a point",
+        :initial_prompt  => "where is the midpoint",
+        :give_up => "sorry",
+        :confirm_correct => "correct",
+        :correct_answer => 0.3,
+        :data_set       => @data_set
+      })
+      @text_hint = TextHint.create({
+        name: "No",
+        text: "<p> not that one!</p>"
+      })
+      @visual_prompt = RangeVisualPrompt.create({
+        name: "RangeVisualPrompt",
+        x_min: 0,
+        x_max: 10,
+        color: "#fee"
+      })
+      @text_hint_prompt = TextHintPrompt.create({
+        prompt: @visual_prompt
+      })
+      @text_hint.text_hint_prompts << @text_hint_prompt
+      @numeric_sequence.text_hints << @text_hint
+      @page2.numeric_sequences << @numeric_sequence
+      @original.pages << @page2
       @original.copy_activity
     end
 
@@ -147,6 +173,18 @@ describe Activity do
 
     it "should match original" do
       subject.to_hash.should == @original.to_hash
+    end
+
+    it "should generate valid json" do
+      subject.validate_runtime_json.should be_true
+    end
+
+    it "should have two pages" do
+      subject.pages.should have(2).pages
+    end
+
+    it "should have a numeric sequence on the second page" do
+      subject.pages[1].numeric_sequences.should have(1).sequence
     end
 
     it "should have a label set with two graph labels" do

--- a/spec/models/line_construction_sequence_spec.rb
+++ b/spec/models/line_construction_sequence_spec.rb
@@ -43,5 +43,5 @@ describe LineConstructionSequence do
       @instance.to_hash.should == expected_hash
     end
   end
-  
+
 end

--- a/spec/models/line_construction_sequence_spec.rb
+++ b/spec/models/line_construction_sequence_spec.rb
@@ -22,6 +22,7 @@ describe LineConstructionSequence do
 
     it "should produce the correct hash" do
       expected_hash = {
+        "title"               => "new line construction",
         "type"                => "LineConstructionSequence",
         "slope"               => 1.0,
         "slopeTolerance"      => 0.1,

--- a/spec/models/numeric_sequence_spec.rb
+++ b/spec/models/numeric_sequence_spec.rb
@@ -44,6 +44,21 @@ describe NumericSequence do
         subject.should have_key 'dataSetName'
         subject['dataSetName'].should == "dataSetA"
       end
+
+      it "Correctly represents the title" do
+        subject['title'].should == 'pick a point'
+      end
+    end
+
+    describe "from_hash" do
+      let(:the_hash) { @sequence.to_hash }
+      subject do
+        NumericSequence.build_object_from_hash(the_hash,nil)
+      end
+      it "title" do
+        the_hash['title'].should == @sequence.title
+        subject.title.should == @sequence.title
+      end
     end
   end
 


### PR DESCRIPTION
Previous approach would try to invoke non-existant methods, and rescue.
rescue attempt would also throw NameErrors.

:any_prompt was vestigile, and not used anywhere.

This still needs better testing. Current specs pass, and smoke-tests run fine.

https://www.pivotaltracker.com/story/show/70895706
